### PR TITLE
fix(common): add required gcc and python3-devel packages

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -5,7 +5,7 @@
     state: present
   become: yes
 - name: Install the_silver_searcher
-  yum:
+  dnf:
     name:
       - the_silver_searcher
     state: present
@@ -15,6 +15,8 @@
     - name: From dnf
       dnf:
         name:
+          - gcc
+          - python3-devel
           - jq
           - socat
           - unzip


### PR DESCRIPTION
Otherwise some of the `pip` requirements cannot be installed since a few
require some compilation.